### PR TITLE
docs: refine README and add Use Cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,48 @@
 # Founder Idea Analyzer
 
-Founder Idea Analyzer is a lightweight startup-evaluation workbench. A founder fills in the Idea Definition form, the backend generates LLM-backed scores plus a Lean Canvas draft, and the frontend visualises the results with a radar chart, mentor dashboard, and colourful UI.
+Founder Idea Analyzer is a lightweight startup-evaluation workbench. Founders submit an idea through a structured form, and the app generates LLM-backed scores plus a Lean Canvas draft that can be reviewed over time.
 
-## Features
+## Why this project
 
-- **Idea Definition Form** – Capture problem, solution, target audience, competitors, and technology choices.
-- **LLM Insight Engine** – Talks to a local Ollama model to produce six quantitative scores and a Lean Canvas JSON block.
-- **Mentor Dashboard** – Shows awareness delta, blind spots, revision comparisons, and a weekly summary.
-- **Versioning API** – Append new revisions, list version history, and compare first vs latest to highlight deltas.
-- **Responsive UI** – Modern beige theme, centered analysis results, lean canvas grid, and Chart.js radar visual.
+Early-stage ideas usually suffer from two gaps:
+
+1. **Unstructured thinking** (great intuition, weak articulation)
+2. **No revision loop** (changes happen, but insight history gets lost)
+
+This project helps founders turn rough concepts into comparable, iterative snapshots they can discuss with mentors, teammates, or investors.
+
+## Core Features
+
+- **Idea Definition Form** – Capture problem, solution, target audience, competitors, and technology choices in one place.
+- **LLM Insight Engine** – Uses a local Ollama model to generate six quantitative scores and a Lean Canvas JSON draft.
+- **Mentor Dashboard** – Highlights awareness deltas, blind spots, revision comparisons, and a weekly summary view.
+- **Versioning API** – Add revisions, browse version history, and compare first vs. latest submissions.
+- **Responsive UI** – Includes a modern beige theme, centered analysis output, Lean Canvas grid, and a Chart.js radar chart.
+
+## Use Cases
+
+- **Solo founder pre-validation**  
+  Pressure-test an idea before writing a full business plan.
+- **Accelerator or incubator intake**  
+  Standardize how mentors review multiple startup ideas each week.
+- **Founder-mentor weekly check-ins**  
+  Compare revisions over time to track learning velocity and strategic clarity.
+- **Hackathon-to-startup transition**  
+  Convert a prototype concept into a more structured venture hypothesis.
+- **Startup education programs**  
+  Use the scoring + Lean Canvas output as a teaching aid for entrepreneurship cohorts.
 
 ## Tech Stack
 
-- **Backend:** Node.js + Express, MongoDB (with in-memory fallback).
-- **Frontend:** Vanilla HTML/CSS/JS with Chart.js.
-- **AI:** Ollama model (defaults to `llama3.1:8b`).
+- **Backend:** Node.js + Express, MongoDB (with in-memory fallback)
+- **Frontend:** Vanilla HTML/CSS/JS with Chart.js
+- **AI:** Ollama model (defaults to `llama3.1:8b`)
 
 ## Prerequisites
 
 - Node.js 18+
-- MongoDB (local or remote) if you want persistence
-- [Ollama](https://ollama.com/) running locally with the model you configure (`llama3.1:8b`).
+- MongoDB (local or remote) for persistence
+- [Ollama](https://ollama.com/) running locally with your configured model (default: `llama3.1:8b`)
 
 ## Setup
 
@@ -32,7 +54,7 @@ npm install
 
 Create a `.env` file (copy `.env.example` if present) and set at least:
 
-```
+```env
 MONGO_URI=mongodb://127.0.0.1:27017/founder-idea
 LLM_PROVIDER=ollama
 OLLAMA_MODEL=llama3.1:8b
@@ -42,9 +64,9 @@ PORT=4000
 Start MongoDB and Ollama locally, then run:
 
 ```bash
-npm start        # runs node server.js
+npm start
 # or
-npm run dev      # if you have nodemon installed
+npm run dev
 ```
 
 Visit <http://localhost:4000>.
@@ -54,19 +76,19 @@ Visit <http://localhost:4000>.
 | Method | Endpoint | Description |
 | --- | --- | --- |
 | POST | `/api/ideas` | Create a new idea, generate insights + Lean Canvas |
-| GET | `/api/ideas/:id` | Fetch idea with latest insights |
+| GET | `/api/ideas/:id` | Fetch an idea with its latest insights |
 | POST | `/api/ideas/:id/versions` | Append a new revision/version |
 | GET | `/api/ideas/:id/versions` | List all versions |
-| GET | `/api/ideas/:id/compare` | Compare first vs latest version and return deltas |
-| GET | `/health` | Simple health-check |
+| GET | `/api/ideas/:id/compare` | Compare first vs. latest version and return deltas |
+| GET | `/health` | Simple health check |
 
-All idea endpoints require `LLM_PROVIDER=ollama` because the heuristic fallback has been removed.
+> All idea endpoints require `LLM_PROVIDER=ollama` because the heuristic fallback has been removed.
 
 ## Development Notes
 
-- Frontend assets live under `public/`. `public/app.js` wires the form to the API, renders charts, and drives the mentor dashboard.
-- `lib/insightEngine.js` contains the prompts for score generation and Lean Canvas drafting.
-- `routes/ideas.js` hosts all persistence logic and the in-memory fallback for demo scenarios.
+- Frontend assets live under `public/`; `public/app.js` wires form submission, chart rendering, and mentor dashboard behavior.
+- `lib/insightEngine.js` contains prompt logic for score generation and Lean Canvas drafting.
+- `routes/ideas.js` contains persistence logic and the in-memory fallback for demo scenarios.
 - `scripts/` includes helper utilities for seeding and exporting demo data.
 
-Feel free to open an issue or fork the repo if you want to extend the prompts, add tests, or plug in another LLM provider.
+Contributions are welcome—open an issue or fork the repo to extend prompts, add test coverage, or integrate additional LLM providers.


### PR DESCRIPTION
### Motivation

- Clarify the project's purpose and real-world value so new users can quickly understand when to use it.
- Provide concrete "Use Cases" to show practical scenarios (founder validation, accelerators, mentor check-ins, hackathons, education).
- Preserve existing functionality and project elements while improving phrasing and consistency.

### Description

- Rewrote the README intro and added a `Why this project` section to better explain the problem the app solves.
- Added a dedicated `Use Cases` section with five practical scenarios for adoption and evaluation.
- Polished formatting and wording across setup, environment examples (changed to a `env` code block), API table descriptions, and development notes for clearer, consistent documentation.
- Kept all original technical details (stack, endpoints, behavior) unchanged while improving copy and layout.

### Testing

- Ran the test suite with `npm test -- --runInBand` and all automated tests passed.
- `jest` reported: `Test Suites: 2 passed, 2 total` and `Tests: 7 passed, 7 total`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8599eb6108329a09850261ec5946c)